### PR TITLE
POST instead of PUT when issuing repurchased product

### DIFF
--- a/seq/card-repurchase.txt
+++ b/seq/card-repurchase.txt
@@ -37,7 +37,7 @@ traveller<->foreignSales: Payment means register at\nhome sales channel\n(see fl
 end 
 
 
-foreignSales->homeSales: Issue product set (set issued status)\n""PUT /productSet/{productSetIdentifier}/status""
+foreignSales->homeSales: Issue product set (set issued status)\n""POST /productSet/{productSetIdentifier}/issue""
 
 box over homeSales: Home Sales Channel calls off the\nmanifests and combines the product set 
 


### PR DESCRIPTION
POST because it should be possible to supply a transaction reference and a transaction ID.