### PR TITLE
Add ability to discover available productProperties

### DIFF
--- a/traveller.yaml
+++ b/traveller.yaml
@@ -14,9 +14,6 @@ paths:
       tags:
         - traveller
       summary: Search for traveller
-      description: |
-        Get information on all travellers matching the search critera 
-        specified by the parameters. 
       operationId: searchTravellerInformation
       produces:
         - application/json
@@ -64,9 +61,6 @@ paths:
       tags:
         - traveller
       summary: Create traveller
-      description: |
-        Create a new entry in the traveller account database with the specified
-        traveller information. 
       operationId: createTravellerInformation
       consumes:
         - application/json
@@ -91,15 +85,11 @@ paths:
             location:
               description: URL of traveller information
               type: string
-              format: uri
   '/traveller/{travellerId}':
     get:
       tags:
         - traveller
       summary: Get traveller information
-      description: |
-        Get information on the traveller with the specified traveller 
-        identifier.
       operationId: getTravellerInformation
       produces:
         - application/json
@@ -123,9 +113,6 @@ paths:
       tags:
         - traveller
       summary: Update traveller information
-      description: |
-        Update traveller information in the traveller account database on the 
-        traveller with the specified traveller identifier.
       operationId: updateTravellerInformation
       consumes:
         - application/json
@@ -153,9 +140,6 @@ paths:
       tags:
         - traveller
       summary: Delete traveller information
-      description: |
-        Delete the traveller with the provided traveller identifier from the 
-        traveller account database.
       operationId: deleteTravellerInformation
       parameters:
         - name: X-BoB-AuthToken
@@ -176,9 +160,6 @@ paths:
       tags:
         - traveller
       summary: Get information on traveller's wallet
-      description: |
-        Retrieve information on the payment means available in the wallet of
-        the traveller with the provided traveller identifier.
       operationId: getTravellerWalletInformation
       produces:
         - application/json
@@ -203,10 +184,6 @@ paths:
       tags:
         - traveller
       summary: Perform transaction on travellers wallet
-      description: |
-        Create a transaction on the specified payment means of the traveller
-        with the specified traveller identifier, optionally first making a
-        reservation of the amount before the transaction is finally committed.
       operationId: postTravellerWalletTransactionRequest
       consumes:
         - application/json
@@ -236,7 +213,6 @@ paths:
             location:
               description: URL of the created transaction
               type: string
-              format: uri
         '401':
           description: Unauthorised
         '403':
@@ -248,10 +224,6 @@ paths:
       tags:
         - traveller
       summary: Get information on traveller's wallet transaction
-      description: |
-        Retrieve information on a specific transaction with the given
-        transaction identifier made on a wallet tied to the traveller with the
-        given traveller identifier.
       operationId: getTransactionInformation
       produces:
         - application/json
@@ -282,11 +254,6 @@ paths:
       tags:
         - traveller
       summary: Update transaction
-      description: |
-        Commit the specified transaction of the traveller with the
-        specified traveller identifier, which has been previously created as a
-        reservation of an amount, or revert a committed transaction by
-        cancelling it.
       operationId: updateTransactionInformation
       consumes:
         - application/json
@@ -321,7 +288,6 @@ paths:
             location:
               description: URL of the updated transaction
               type: string
-              format: uri
         '401':
           description: Unauthorised
         '403':
@@ -331,9 +297,6 @@ paths:
       tags:
         - traveller
       summary: Post notification to traveller
-      description: |
-        Post a notification to the traveller with the specified traveller 
-        identifier.
       operationId: sendTravellerNotification
       consumes:
         - application/json
@@ -361,15 +324,11 @@ paths:
             location:
               description: URL of created notification
               type: string
-              format: uri
   '/traveller/{travellerId}/notification/{notificationId}':
     get:
       tags:
         - traveller
       summary: Get notification sent to traveller
-      description: |
-        Retrieve information on a notification previously posted to the
-        traveller with the specified traveller identifier.
       operationId: getTravellerNotification
       produces:
         - application/json
@@ -399,9 +358,6 @@ paths:
       tags:
         - token
       summary: Get information on products sets tied to token
-      description: |
-        Retrieve information on the set of products which has been tied to a
-        token with the specified token identifier.
       operationId: getTokenProductSetInformation
       produces:
         - application/json
@@ -433,9 +389,6 @@ paths:
       tags:
         - token
       summary: Get challenge to authenticate token
-      description: |
-        Retrieve a challenge to be used as authentication input for verifying
-        prossession of private key of a token.
       operationId: getTokenChallenge
       produces:
         - application/json
@@ -460,10 +413,6 @@ paths:
       tags:
         - token
       summary: Purchase ticket on behalf of traveller
-      description: |
-        Make a purchase of the product with the provided product identifier,
-        from the participant with the given participant identifier, on behalf
-        of the traveller registered as holder of the given token ID.
       operationId: requestTokenTicket
       parameters:
         - name: X-BoB-AuthToken
@@ -489,9 +438,6 @@ paths:
             location:
               description: URL of created ticket bundle
               type: string
-              format: uri
-          schema:
-            $ref: '#/definitions/productSetInformation'
         '402':
           description: Payment declined
   '/token/{tokenId}/wallet':
@@ -499,9 +445,6 @@ paths:
       tags:
         - token
       summary: Get information on wallet tied to token
-      description: |
-        Retrieve information on the payment means in a wallet which has been 
-        tied to a token with the specified token identifier.
       operationId: getTokenWalletInformation
       produces:
         - application/json
@@ -526,10 +469,6 @@ paths:
       tags:
         - token
       summary: Perform transaction on wallet tied to token
-      description: |
-        Create a transaction with the given amount on the wallet tied to the
-        token with the given token identifier, optionally providing information
-        on the desired payment means.
       operationId: postTokenWalletTransactionRequest
       consumes:
         - application/json
@@ -559,7 +498,6 @@ paths:
             location:
               description: URL of the created transaction
               type: string
-              format: uri
         '401':
           description: Unauthorised
         '403':
@@ -571,10 +509,6 @@ paths:
       tags:
         - token
       summary: Get information on transaction tied to token
-      description: |
-        Retrieve information on a specific transaction with the given
-        transaction identifier made on a wallet tied to the token with the
-        given token identifier.
       operationId: getTokenTransactionInformation
       produces:
         - application/json
@@ -605,10 +539,6 @@ paths:
       tags:
         - token
       summary: Update transaction tied to token
-      description: |
-        Commit the specified transaction of the token with the specified token
-        identifier, which has been previously created as a reservation of an
-        amount, or revert a committed transaction by cancelling it.
       operationId: updateTokenTransactionInformation
       consumes:
         - application/json
@@ -643,7 +573,6 @@ paths:
             location:
               description: URL of the updated transaction
               type: string
-              format: uri
         '401':
           description: Unauthorised
         '403':
@@ -653,9 +582,6 @@ paths:
       tags:
         - mtb
       summary: Get information on product sets in MTB
-      description: |
-        Retrieve information on the product set(s) contained within a specific
-        MTB with the provided Issuer Signature.
       operationId: getMTBProductSetInformation
       produces:
         - application/json
@@ -667,7 +593,7 @@ paths:
           type: string
         - name: issuerSignature
           in: path
-          description: MTB Issuer Signature
+          description: MTB issuer signature
           required: true
           type: string
           format: base64url
@@ -685,10 +611,6 @@ paths:
       tags:
         - mtb
       summary: Activate MTB
-      description: |
-        Activate tickets contained within a MTB with the given Issuer
-        Signature, possibly across multiple participants, by providing the
-        Ticket Identifier of the ticket triggering the activation.
       operationId: activateMTB
       produces:
         - application/json
@@ -724,9 +646,6 @@ paths:
       tags:
         - productSet
       summary: Get information on product set
-      description: |
-        Retrieve information on a Product Set with the given Product Set
-        identifier
       operationId: getProductSetInformation
       produces:
         - application/json
@@ -769,8 +688,8 @@ paths:
           required: true
           type: string
       responses:
-        '204':
-          description: Product set deleted
+        '200':
+          description: Successful operation
         '401':
           description: Unauthorised
         '403':
@@ -815,7 +734,7 @@ paths:
     post:
       tags:
         - productSet
-      summary: Request refund of an issued product set
+      summary: Requst refund of an issued product set
       operationId: refundProductSet
       consumes:
         - application/json
@@ -844,7 +763,7 @@ paths:
     post:
       tags:
         - productSet
-      summary: Request revocation of an issued product set
+      summary: Requst revokation of an issued product set
       operationId: revokeProductSet
       consumes:
         - application/json
@@ -875,10 +794,6 @@ paths:
       tags:
         - productSet
       summary: Recreate an equivalent product set
-      description: |
-        Recreate an equivalent product set to that of the given product set
-        identifier, with the specified product set options, setting the status
-        to recreated if successful.
       operationId: recreateProductSet
       consumes:
         - application/json
@@ -909,7 +824,6 @@ paths:
             location:
               description: URL of recreated product set
               type: string
-              format: uri
         '401':
           description: Unauthorised
         '403':
@@ -920,10 +834,6 @@ paths:
       tags:
         - ticketNotification
       summary: Notification on ticket event
-      description: |
-        Post a ticket event notification, instructing the sales channel to
-        update itself on the status of the ticket with the specified ticket
-        identifier.
       operationId: createTicketNotification
       consumes:
         - application/json
@@ -944,7 +854,7 @@ paths:
         '401':
           description: Unauthorised
         '403':
-          description: Forbidden, creation of ticket event notification failed
+          description: Forbidden, creation failed
 
 definitions:
 
@@ -1313,12 +1223,30 @@ definitions:
       value:
         description: Product property value
         type: string
+
+  productPropertyDeclaration:
+    description: |
+      Product properties declaration. Contains identifier, type, description
+      and an optional default value.
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        description: Product property name
+        type: string
+      default:
+        description: Product property default value
+        type: string
+      mandatory:
+        description: Product property prerequisite for product
+        type: boolean
       description:
         description: Product property description
         type: string
-      surcharge:
-        description: Product property surcharge
-        $ref: '#/definitions/fare'
+      type:
+        description: Product property type (primitive json types)
+        type: string
       surcharges:
         description: |
           Product property surcharges. Can be several entries when surcharges include product property surcharges, discounts, different
@@ -1411,6 +1339,7 @@ definitions:
     type: string
     enum:
       - activated
+      - cancelled
       - expired
       - issued
       - recreated
@@ -1480,6 +1409,10 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/productProperty'
+      availableProductProperties:
+        type: array
+        items:
+          $ref: '#/definitions/productPropertyDeclaration'
 
   timeConstraints:
     description: Bundle time constraints
@@ -1678,13 +1611,9 @@ definitions:
 
   activationData:
     type: object
-    required:
-    - pid
-    - ticketId
     properties:
-      timeOfActivation:
-        description: Date and time for activation (default NOW) as ISO 8601:2004 profile 
-          extended format (MTS8, chapter 2.3)
+      activationDateTime:
+        description: Date and time for activation (default NOW)
         type: string
         format: date-time
       pid:


### PR DESCRIPTION
This change adds the ability to discover available (and possibly mandatory) productProperties through the traveller API (which can/must be set to issue a ticket) when recreating a product. The idea is that a recreated product set will then contain the productPropertiesDeclaration object which indicated which options can be set (but is currently not set). To set one or more of these productProperties, a new product set shall be (re)created and the previously recreated one can be discarded.

See seq/card-repurchase-with-options.txt.
